### PR TITLE
Careful reading

### DIFF
--- a/lib/thermex/mtime.ex
+++ b/lib/thermex/mtime.ex
@@ -1,0 +1,9 @@
+defmodule Thermex.Mtime do
+  require Record
+  Record.defrecord :file_info, Record.extract(:file_info, from_lib: "kernel/include/file.hrl")
+
+  def check(filepath) do
+    with {:ok, file_info} <- :file.read_file_info(filepath, time: :posix),
+    do: {:ok, file_info(file_info, :mtime)}
+  end
+end

--- a/lib/thermex/parser.ex
+++ b/lib/thermex/parser.ex
@@ -1,8 +1,8 @@
 defmodule Thermex.Parser do
   def parse(reading) do
     reading
+    |> String.strip
     |> String.split("\n")
-    |> Enum.map(&String.strip/1)
     |> parse_temperature
   end
 

--- a/lib/thermex/parser.ex
+++ b/lib/thermex/parser.ex
@@ -1,0 +1,23 @@
+defmodule Thermex.Parser do
+  def parse(reading) do
+    reading
+    |> String.split("\n")
+    |> Enum.map(&String.strip/1)
+    |> parse_temperature
+  end
+
+  defp parse_temperature(["00 00 00 00 00 00 00 00 00 : crc=00"<>_, _line2]) do
+    {:error, :untrusted_reading}
+  end
+  defp parse_temperature([<<_hex :: binary-size(36), "YES">>, line2]) do
+    [_,temperature_str] = String.split(line2, "=")
+    {temperature_int, ""} = Integer.parse(temperature_str)
+    {:ok, temperature_int / 1000}
+  end
+  defp parse_temperature([<<_hex :: binary-size(36), "NO">>, _line2]) do
+    {:error, :crc_not_matched}
+  end
+  defp parse_temperature([_,_]) do
+    {:error, :unknown}
+  end
+end

--- a/test/mtime_test.exs
+++ b/test/mtime_test.exs
@@ -1,0 +1,13 @@
+defmodule Thermex.MtimeTest do
+  use ExUnit.Case, async: true
+  import Thermex.Mtime, only: [check: 1]
+
+  test "returns the posix mtime of a filepath" do
+    assert {:ok, posix} = check(Path.join(__DIR__, "mtime_test.exs"))
+    assert is_integer(posix)
+  end
+
+  test "returns an error message for invalid filepaths" do
+    assert {:error, :enoent} == check("/fake/file.path")
+  end
+end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -3,12 +3,12 @@ defmodule Thermex.ParserTest do
   import Thermex.Parser, only: [parse: 1]
 
   test "parses valid readings and returns the degrees celsius" do
-    assert {:ok, temp} = parse("55 01 4b 46 7f ff 0b 10 d0 : crc=d0 YES\n55 01 4b 46 7f ff 0b 10 d0 t=21312")
+    assert {:ok, temp} = parse("55 01 4b 46 7f ff 0b 10 d0 : crc=d0 YES\n55 01 4b 46 7f ff 0b 10 d0 t=21312\n")
     assert_in_delta temp, 21.312, 0.001
   end
 
   test "returns an error when the CRC doesn't match" do
-    assert {:error, :crc_not_matched} == parse("ff ff ff ff ff ff ff ff ff : crc=c9 NO\n53 01 4b 46 7f ff 0d 10 e9 t=-62")
+    assert {:error, :crc_not_matched} == parse("ff ff ff ff ff ff ff ff ff : crc=c9 NO\n53 01 4b 46 7f ff 0d 10 e9 t=-62\n")
   end
 
   # This test covers an edge case where a sensor wire that gets unplugged
@@ -16,6 +16,6 @@ defmodule Thermex.ParserTest do
   # notices that the sensor is gone. During this time period the CRC will match
   # because the sum of 0's is always 0, but we don't want to accept these readings
   test "returns an error when the reading is all 0's" do
-    assert {:error, :untrusted_reading} == parse("00 00 00 00 00 00 00 00 00 : crc=00 YES\n00 00 00 00 00 00 00 00 00 t=0")
+    assert {:error, :untrusted_reading} == parse("00 00 00 00 00 00 00 00 00 : crc=00 YES\n00 00 00 00 00 00 00 00 00 t=0\n")
   end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -1,0 +1,21 @@
+defmodule Thermex.ParserTest do
+  use ExUnit.Case, async: true
+  import Thermex.Parser, only: [parse: 1]
+
+  test "parses valid readings and returns the degrees celsius" do
+    assert {:ok, temp} = parse("55 01 4b 46 7f ff 0b 10 d0 : crc=d0 YES\n55 01 4b 46 7f ff 0b 10 d0 t=21312")
+    assert_in_delta temp, 21.312, 0.001
+  end
+
+  test "returns an error when the CRC doesn't match" do
+    assert {:error, :crc_not_matched} == parse("ff ff ff ff ff ff ff ff ff : crc=c9 NO\n53 01 4b 46 7f ff 0d 10 e9 t=-62")
+  end
+
+  # This test covers an edge case where a sensor wire that gets unplugged
+  # will read as all 0's for a period of time before the operating system
+  # notices that the sensor is gone. During this time period the CRC will match
+  # because the sum of 0's is always 0, but we don't want to accept these readings
+  test "returns an error when the reading is all 0's" do
+    assert {:error, :untrusted_reading} == parse("00 00 00 00 00 00 00 00 00 : crc=00 YES\n00 00 00 00 00 00 00 00 00 t=0")
+  end
+end


### PR DESCRIPTION
Fixes #1 

This splits the temperature parsing into its own module (with some tests) and switches the monitor to use the new parsing module. I also made it so that the monitor publishes failure messages in case you care about those.

I think we should bump the minor version for this change because if people were previously receiving these messages and just assuming that the second item in the tuple was a a float, their code might break since the second item in the tuple can now be an error tuple.

/cc @newellista @ztoolson
